### PR TITLE
Chrisbc/ruptset diags iframe

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,14 +5,17 @@
   "dependencies": {
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
+    "@react-leaflet/core": ">=1.0.2 <1.1.0 || ^1.1.1",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "build-url-ts": "^6.0.1",
     "d3": "^6.7.0",
     "date-fns": "^2.22.1",
+    "leaflet": "^1.7.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-leaflet": ">=3.1.0 <3.2.0 || ^3.2.1",
     "react-markdown": "^6.0.2",
     "react-relay": "^11.0.2",
     "react-router-dom": "^5.2.0",
@@ -41,21 +44,15 @@
       "react-app/jest"
     ]
   },
-  "browserslist": {
-    "production": [
+  "browserslist": [
       ">0.2%",
       "not dead",
       "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
+   ],
   "devDependencies": {
     "@types/d3": "^6.7.0",
     "@types/jest": "^26.0.23",
+    "@types/leaflet": "^1.7.1",
     "@types/node": "^15.3.0",
     "@types/react": "^17.0.5",
     "@types/react-dom": "^17.0.5",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "build-url-ts": "^6.0.1",
     "d3": "^6.7.0",
     "date-fns": "^2.22.1",
     "react": "^17.0.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import Search from './components/Search';
 import PreviewMFD from './components/PreviewMFD';
 import PreviewLineMFD from './components/PreviewLineMFD';
 import GeneralTask from './components/GeneralTask';
+import RuptureSetDiags from './components/RuptureSetDiags';
 
 const useStyles = makeStyles({
   root: {
@@ -147,14 +148,17 @@ function AppRoot(props: { environment?: Environment }): React.ReactElement {
               <Route path="/Search">
                 <Search />
               </Route>
-              <Route path="/PreviewMFD">
-                <PreviewMFD />
-              </Route>
-              <Route path="/PreviewLineMFD">
-                <PreviewLineMFD />
-              </Route>
               <Route path="/GeneralTask/:id">
                 <GeneralTask />
+              </Route>
+              <Route path="/preview/MFD">
+                <PreviewMFD />
+              </Route>
+              <Route path="/Preview/lineMFD">
+                <PreviewLineMFD />
+              </Route>
+              <Route path="/preview/diags">
+                <RuptureSetDiags />
               </Route>
               <Route path="/">
                 <App preloadedQuery={preloadedQuery} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,9 @@ import './App.css';
 import logo from './logo.svg';
 
 import { graphql } from 'babel-plugin-relay/macro';
-
 import { Environment, loadQuery, PreloadedQuery, RelayEnvironmentProvider, usePreloadedQuery } from 'react-relay/hooks';
-
 import RelayEnvironment from './RelayEnvironment';
-
 import { AppStrongMotionStationQuery } from './__generated__/AppStrongMotionStationQuery.graphql';
-
 import { makeStyles } from '@material-ui/core/styles';
 import {
   Box,
@@ -26,9 +22,11 @@ import { BrowserRouter, Switch, Route } from 'react-router-dom';
 import RuptureGenerationTask from './components/RuptureGenerationTask';
 import FileDetail from './components/FileDetail';
 import Search from './components/Search';
+import GeneralTask from './components/GeneralTask';
+
+import Preview from './components/Preview';
 import PreviewMFD from './components/PreviewMFD';
 import PreviewLineMFD from './components/PreviewLineMFD';
-import GeneralTask from './components/GeneralTask';
 import RuptureSetDiags from './components/RuptureSetDiags';
 import RuptureSetViews from './components/RuptureSetViews';
 import HazardMap from './components/HazardMap';
@@ -154,9 +152,9 @@ function AppRoot(props: { environment?: Environment }): React.ReactElement {
                 <GeneralTask />
               </Route>
               <Route path="/preview/MFD">
-                <PreviewMFD />
+                <PreviewMFD width={800} height={600} bar_width={15} />
               </Route>
-              <Route path="/Preview/lineMFD">
+              <Route path="/preview/lineMFD">
                 <PreviewLineMFD />
               </Route>
               <Route path="/preview/diags">
@@ -167,6 +165,9 @@ function AppRoot(props: { environment?: Environment }): React.ReactElement {
               </Route>
               <Route path="/preview/hazard">
                 <HazardMap />
+              </Route>
+              <Route path="/preview">
+                <Preview />
               </Route>
               <Route path="/">
                 <App preloadedQuery={preloadedQuery} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,8 @@ import PreviewMFD from './components/PreviewMFD';
 import PreviewLineMFD from './components/PreviewLineMFD';
 import GeneralTask from './components/GeneralTask';
 import RuptureSetDiags from './components/RuptureSetDiags';
+import RuptureSetViews from './components/RuptureSetViews';
+import HazardMap from './components/HazardMap';
 
 const useStyles = makeStyles({
   root: {
@@ -159,6 +161,12 @@ function AppRoot(props: { environment?: Environment }): React.ReactElement {
               </Route>
               <Route path="/preview/diags">
                 <RuptureSetDiags />
+              </Route>
+              <Route path="/preview/views">
+                <RuptureSetViews />
+              </Route>
+              <Route path="/preview/hazard">
+                <HazardMap />
               </Route>
               <Route path="/">
                 <App preloadedQuery={preloadedQuery} />

--- a/src/components/HazardMap.tsx
+++ b/src/components/HazardMap.tsx
@@ -1,13 +1,13 @@
 import { LatLngExpression } from 'leaflet';
 import 'leaflet/dist/leaflet.css';
-import { MapContainer, Marker, TileLayer, Popup } from 'react-leaflet';
+import { MapContainer, TileLayer } from 'react-leaflet';
 import React from 'react';
 import { Typography, Box, Card } from '@material-ui/core';
 
 const HazardMap: React.FC = () => {
   // Default coordinates set to Masterton station
   const nz_centre: LatLngExpression = [-40.946, 174.167];
-  const position: LatLngExpression = [-40.946, 175.667]; //Masterton
+  // const position: LatLngExpression = [-40.946, 175.667]; //Masterton
   const zoom = 5;
 
   //L.tileLayer.provider('Esri.DeLorme').;

--- a/src/components/HazardMap.tsx
+++ b/src/components/HazardMap.tsx
@@ -1,0 +1,54 @@
+import { LatLngExpression } from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { MapContainer, Marker, TileLayer, Popup } from 'react-leaflet';
+import React from 'react';
+import { Typography, Box, Card } from '@material-ui/core';
+
+const HazardMap: React.FC = () => {
+  // Default coordinates set to Masterton station
+  const nz_centre: LatLngExpression = [-40.946, 174.167];
+  const position: LatLngExpression = [-40.946, 175.667]; //Masterton
+  const zoom = 5;
+
+  //L.tileLayer.provider('Esri.DeLorme').;
+
+  // var Stadia_Outdoors = L.tileLayer(
+  //   'https://tiles.stadiamaps.com/tiles/outdoors/{z}/{x}/{y}{r}.png', {
+  //   maxZoom: 20,
+  //   attribution: '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/">OpenMapTiles</a> &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
+  // });
+  // var Esri_OceanBasemap = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/Ocean_Basemap/MapServer/tile/{z}/{y}/{x}', {
+  //   attribution: 'Tiles &copy; Esri &mdash; Sources: GEBCO, NOAA, CHS, OSU, UNH, CSUMB, National Geographic, DeLorme, NAVTEQ, and Esri',
+  //   maxZoom: 13
+  // });
+
+  // const provider_url = 'https://tiles.stadiamaps.com/tiles/outdoors/{z}/{x}/{y}{r}.png';
+  // const provider_attibution =
+  //   '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/">OpenMapTiles</a> &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors';
+
+  const provider_url = 'https://server.arcgisonline.com/ArcGIS/rest/services/Ocean_Basemap/MapServer/tile/{z}/{y}/{x}';
+  const provider_attibution =
+    'Tiles &copy; Esri &mdash; Sources: GEBCO, NOAA, CHS, OSU, UNH, CSUMB, National Geographic, DeLorme, NAVTEQ, and Esri';
+
+  return (
+    <>
+      <Box>
+        <Card>
+          <Typography variant="h5" gutterBottom>
+            Hazard Map
+          </Typography>
+          <MapContainer center={nz_centre} zoom={zoom} scrollWheelZoom={false} style={{ height: '700px' }}>
+            <TileLayer attribution={provider_attibution} url={provider_url} />
+            {/*<Marker position={position}>
+              <Popup>
+                A pretty CSS3 popup. <br /> Easily customizable.
+              </Popup>
+            </Marker>*/}
+          </MapContainer>
+        </Card>
+      </Box>
+    </>
+  );
+};
+
+export default HazardMap;

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+
+import { makeStyles } from '@material-ui/core/styles';
+// prettier-ignore
+import {
+  Button,
+  Card,
+  CardContent,
+  Container,
+  Typography,
+} from '@material-ui/core';
+
+const useStyles = makeStyles({
+  root: {
+    minWidth: 275,
+  },
+  bullet: {
+    display: 'inline-block',
+    margin: '0 2px',
+    transform: 'scale(0.8)',
+  },
+  pos: {
+    marginBottom: 3,
+  },
+});
+
+function Preview(): React.ReactElement {
+  const classes = useStyles();
+
+  return (
+    <Container>
+      <Typography color="textPrimary" variant="h4" gutterBottom>
+        Preview features
+      </Typography>
+      <Card className={classes.root}>
+        <CardContent>
+          <Typography color="textPrimary" variant="h5" gutterBottom>
+            MFD Histogram
+          </Typography>
+          <Typography className={classes.pos} component="p">
+            A traditional histogram, can use variable bin widths.
+            <Button size="small" href="/preview/MFD">
+              go
+            </Button>
+          </Typography>
+        </CardContent>
+      </Card>
+
+      <Card className={classes.root}>
+        <CardContent>
+          <Typography color="textPrimary" variant="h5" gutterBottom>
+            Line MFD
+          </Typography>
+          <Typography className={classes.pos} component="p">
+            A replica of the multi series MFD seen in opensha Named Faults plots. Uses log scaling
+            <Button size="small" href="/preview/LineMFD">
+              go
+            </Button>
+          </Typography>
+        </CardContent>
+      </Card>
+
+      <Card className={classes.root}>
+        <CardContent>
+          <Typography color="textPrimary" variant="h5" gutterBottom>
+            Hazard
+          </Typography>
+          <Typography className={classes.pos} component="p">
+            An interactive map using `leaflet`.
+            <Button size="small" href="/preview/hazard">
+              go
+            </Button>
+          </Typography>
+        </CardContent>
+      </Card>
+
+      <Card className={classes.root}>
+        <CardContent>
+          <Typography color="textPrimary" variant="h5" gutterBottom>
+            Inline report Rupture Set Diagnostics
+          </Typography>
+          <Typography className={classes.pos} component="p">
+            Take a static HTML open report and wrap it to make if more usable.
+            <Button size="small" href="/preview/diags">
+              go
+            </Button>
+          </Typography>
+        </CardContent>
+      </Card>
+
+      <Card className={classes.root}>
+        <CardContent>
+          <Typography color="textPrimary" variant="h5" gutterBottom>
+            Mixed static and dynamic content
+          </Typography>
+          <Typography className={classes.pos} component="p">
+            Mix static images and dynamic content - to make if more cohesive.
+            <Button size="small" href="/preview/views">
+              go
+            </Button>
+          </Typography>
+        </CardContent>
+      </Card>
+    </Container>
+  );
+}
+
+/*
+              <Route path="/Preview/lineMFD">
+                <PreviewLineMFD />
+              </Route>
+              <Route path="/preview/diags">
+                <RuptureSetDiags />
+              </Route>
+              <Route path="/preview/views">
+                <RuptureSetViews />
+              </Route>
+              <Route path="/preview/hazard">
+                <HazardMap />
+              </Route>
+*/
+
+export default Preview;

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -105,19 +105,4 @@ function Preview(): React.ReactElement {
   );
 }
 
-/*
-              <Route path="/Preview/lineMFD">
-                <PreviewLineMFD />
-              </Route>
-              <Route path="/preview/diags">
-                <RuptureSetDiags />
-              </Route>
-              <Route path="/preview/views">
-                <RuptureSetViews />
-              </Route>
-              <Route path="/preview/hazard">
-                <HazardMap />
-              </Route>
-*/
-
 export default Preview;

--- a/src/components/PreviewMFD.tsx
+++ b/src/components/PreviewMFD.tsx
@@ -1,16 +1,17 @@
 import * as d3 from 'd3';
 import React, { useRef, useEffect } from 'react';
 import { Typography } from '@material-ui/core';
-
 import { d0, onlyRate } from './PreviewMFD_data';
 
-const PreviewMFD: React.FC = () => {
+function PreviewMFD(props: { width: number; height: number; bar_width: number }): React.ReactElement {
   const ref = useRef<SVGSVGElement>(null);
   const data = onlyRate(d0); //[10, 40, 30, 20, 50, 10];
   // const data = d0; //[10, 40, 30, 20, 50, 10];
   const maxData = d3.max(data) || 0;
-  const width = 800;
-  const height = 600;
+
+  const width = props.width;
+  const height = props.height;
+  const bar_width = props.bar_width;
 
   console.log('DATA', data);
   useEffect(() => {
@@ -36,10 +37,10 @@ const PreviewMFD: React.FC = () => {
     selection
       .enter()
       .append('rect')
-      .attr('x', (d, i) => i * 15)
+      .attr('x', (d, i) => i * bar_width)
       // eslint-disable-next-line
       .attr('y', (d) => height)
-      .attr('width', 12)
+      .attr('width', bar_width - 1)
       .attr('height', 0)
       .attr('fill', 'orange')
       .transition()
@@ -58,11 +59,15 @@ const PreviewMFD: React.FC = () => {
       .remove();
 
     // Handmade legend
-    svg.append('circle').attr('cx', 450).attr('cy', 30).attr('r', 6).style('fill', 'orange');
-    svg.append('circle').attr('cx', 450).attr('cy', 60).attr('r', 6).style('fill', '#404080');
-    svg.append('text').attr('x', 470).attr('y', 36).text('variable A').style('font-size', '15px');
+    // prettier-ignore
+    svg.append('circle').attr('cx', width-150).attr('cy', 30).attr('r', 6).style('fill', 'orange');
+    // prettier-ignore
+    svg.append('circle').attr('cx', width-150).attr('cy', 60).attr('r', 6).style('fill', '#404080');
+    // prettier-ignore
+    svg.append('text').attr('x', width-130).attr('y', 36).text('variable A').style('font-size', '15px');
     svg.attr('alignment-baseline', 'middle');
-    svg.append('text').attr('x', 470).attr('y', 66).text('variable B').style('font-size', '15px');
+    // prettier-ignore
+    svg.append('text').attr('x', width-130).attr('y', 66).text('variable B').style('font-size', '15px');
     svg.attr('alignment-baseline', 'middle');
   };
 
@@ -77,6 +82,6 @@ const PreviewMFD: React.FC = () => {
       </div>
     </>
   );
-};
+}
 
 export default PreviewMFD;

--- a/src/components/RuptureSetDiags.tsx
+++ b/src/components/RuptureSetDiags.tsx
@@ -1,0 +1,68 @@
+import React, { useRef, useEffect } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import CardMedia from '@material-ui/core/CardMedia';
+import Button from '@material-ui/core/Button';
+import { Typography } from '@material-ui/core';
+
+import buildUrl from 'build-url-ts';
+
+const reportBaseUrl = 'http://nzshm22-static-reports.s3-website-ap-southeast-2.amazonaws.com/opensha/DATA';
+//http://nzshm22-rupset-diags-poc.s3-website-ap-southeast-2.amazonaws.com';
+
+const useStyles = makeStyles({
+  root: {
+    maxWidth: 1000,
+  },
+  media: {
+    height: 600,
+  },
+});
+
+// const indexMap: Record<string, string> = {
+//   RmlsZTo3ODYuMGRiR1hT: 'DATA6/RmlsZTo3ODYuMGRiR1hT/',
+//   RmlsZTo3NzEuMGRlR2pw: 'DATA6/RmlsZTo3NzEuMGRlR2pw/',
+// };
+
+const hash = 'subsection-count';
+
+const reportUrl = buildUrl(reportBaseUrl, {
+  path: '/RmlsZTo3ODYuMGRiR1hT' + '/DiagnosticsReport/index.html',
+  hash: hash,
+});
+
+const RuptureSetDiags: React.FC = () => {
+  const classes = useStyles();
+
+  // return <iframe src={reportUrl} width="1000" height="600" />;
+
+  return (
+    <Card className={classes.root}>
+      <CardActionArea>
+        <CardContent>
+          <Typography gutterBottom variant="h5" component="h2">
+            Rupture Set Diagnostics Report {'RmlsZTo3ODYuMGRiR1hT'}
+          </Typography>
+          <Typography variant="body2" color="textSecondary" component="p">
+            fault_model: CFM_0_9_SANSTVZ_D90; min_sub_sects_per_parent: 2; min_sub_sections: 3; max_jump_distance: 15
+            adaptive_min_distance: 6; thinning_factor: 0.0; scaling_relationship: TMG_CRU_2017
+          </Typography>
+        </CardContent>
+        <CardMedia className={classes.media} src={reportUrl} title="DiagnosticsReport" component="iframe" />
+      </CardActionArea>
+      <CardActions>
+        <Button size="small" color="primary">
+          Share
+        </Button>
+        <Button size="small" color="primary">
+          Learn More
+        </Button>
+      </CardActions>
+    </Card>
+  );
+};
+
+export default RuptureSetDiags;

--- a/src/components/RuptureSetDiags.tsx
+++ b/src/components/RuptureSetDiags.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardActionArea from '@material-ui/core/CardActionArea';

--- a/src/components/RuptureSetViews.tsx
+++ b/src/components/RuptureSetViews.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+//import CardActionArea from '@material-ui/core/CardActionArea';
+import {
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CardMedia,
+  CircularProgress,
+  Container,
+  Typography,
+} from '@material-ui/core';
+
+import buildUrl from 'build-url-ts';
+
+const reportBaseUrl = 'http://nzshm22-static-reports.s3-website-ap-southeast-2.amazonaws.com/opensha/DATA';
+//http://nzshm22-rupset-diags-poc.s3-website-ap-southeast-2.amazonaws.com';
+
+const useStyles = makeStyles({
+  root: {
+    maxWidth: 500,
+    display: 'flex',
+  },
+  content: {
+    flex: '1 1 auto',
+  },
+  media: {
+    height: 350, // as an example I am modifying width and height
+    width: '100%',
+    //marginLeft: '5%',
+  },
+});
+
+// const indexMap: Record<string, string> = {
+//   RmlsZTo3ODYuMGRiR1hT: 'DATA6/RmlsZTo3ODYuMGRiR1hT/',
+//   RmlsZTo3NzEuMGRlR2pw: 'DATA6/RmlsZTo3NzEuMGRlR2pw/',
+// };
+
+const view0 = 'resources/hist_MAG.png';
+const view1 = 'resources/sect_max_LENGTH.png';
+
+const file_id = 'RmlsZTo3ODYuMGRiR1hT';
+
+const view0Url = buildUrl(reportBaseUrl, {
+  path: '/' + file_id + '/DiagnosticsReport/' + view0,
+});
+const view1Url = buildUrl(reportBaseUrl, {
+  path: '/' + file_id + '/DiagnosticsReport/' + view1,
+});
+const RuptureSetDiags: React.FC = () => {
+  const classes = useStyles();
+
+  // return <iframe src={reportUrl} width="1000" height="600" />;
+
+  return (
+    <Box>
+      <Typography gutterBottom variant="h5" component="h5">
+        Rupture Set Views {file_id}
+      </Typography>
+      <Typography variant="body2" color="textSecondary" component="p">
+        fault_model: CFM_0_9_SANSTVZ_D90; min_sub_sects_per_parent: 2; min_sub_sections: 3; max_jump_distance: 15
+        adaptive_min_distance: 6; thinning_factor: 0.0; scaling_relationship: TMG_CRU_2017
+      </Typography>
+      <Card className={classes.root} variant="outlined">
+        <CardContent className={classes.content}>
+          <CardMedia className={classes.media} image={view0Url} />
+        </CardContent>
+      </Card>
+      <Card className={classes.root} variant="outlined">
+        <CardContent className={classes.content}>
+          <CardMedia className={classes.media} image={view1Url} />
+        </CardContent>
+      </Card>
+    </Box>
+  );
+};
+
+export default RuptureSetDiags;

--- a/src/components/RuptureSetViews.tsx
+++ b/src/components/RuptureSetViews.tsx
@@ -1,26 +1,22 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-//import CardActionArea from '@material-ui/core/CardActionArea';
+// prettier-ignore
 import {
   Box,
-  Button,
   Card,
-  CardActions,
   CardContent,
   CardMedia,
-  CircularProgress,
-  Container,
   Typography,
 } from '@material-ui/core';
 
 import buildUrl from 'build-url-ts';
+import PreviewMFD from '../components/PreviewMFD';
 
 const reportBaseUrl = 'http://nzshm22-static-reports.s3-website-ap-southeast-2.amazonaws.com/opensha/DATA';
-//http://nzshm22-rupset-diags-poc.s3-website-ap-southeast-2.amazonaws.com';
 
 const useStyles = makeStyles({
   root: {
-    maxWidth: 500,
+    maxWidth: 520,
     display: 'flex',
   },
   content: {
@@ -52,8 +48,6 @@ const view1Url = buildUrl(reportBaseUrl, {
 const RuptureSetDiags: React.FC = () => {
   const classes = useStyles();
 
-  // return <iframe src={reportUrl} width="1000" height="600" />;
-
   return (
     <Box>
       <Typography gutterBottom variant="h5" component="h5">
@@ -63,6 +57,13 @@ const RuptureSetDiags: React.FC = () => {
         fault_model: CFM_0_9_SANSTVZ_D90; min_sub_sects_per_parent: 2; min_sub_sections: 3; max_jump_distance: 15
         adaptive_min_distance: 6; thinning_factor: 0.0; scaling_relationship: TMG_CRU_2017
       </Typography>
+
+      <Card className={classes.root} variant="outlined">
+        <CardContent className={classes.content}>
+          <PreviewMFD width={380} height={300} bar_width={9} />
+        </CardContent>
+      </Card>
+
       <Card className={classes.root} variant="outlined">
         <CardContent className={classes.content}>
           <CardMedia className={classes.media} image={view0Url} />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es5",
     "module": "esnext",
     "lib": [
       "dom",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1578,6 +1578,16 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
+"@react-leaflet/core@>=1.0.2 <1.1.0 || ^1.1.1":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@react-leaflet/core/-/core-1.0.2.tgz#39c6a73f61c666d5dcf673741cea2672fa4bbae1"
+  integrity sha512-QbleYZTMcgujAEyWGki8Lx6cXQqWkNtQlqf5c7NImlIp8bKW66bFpez/6EVatW7+p9WKBOEOVci/9W7WW70EZg==
+
+"@react-leaflet/core@^1.0.2":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@react-leaflet/core/-/core-1.1.0.tgz#389b2b373f1da4caeb3c4cf6f33d84561c58d504"
+  integrity sha512-zFxMHgfjCi7khRVB7o7H8NoJl36NaezvfcaeEurVXx22lAGHFlTHiSuLOGA4tOiHj+Ep+Lo3uwUGJ3YM9BGkHg==
+
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz#80de384edfbd7bfc9101164910f86078151a3eca"
@@ -2118,6 +2128,13 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@types/leaflet@^1.7.1":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@types/leaflet/-/leaflet-1.7.3.tgz#0294806f44081519a8c69593f7d0659d6aefda89"
+  integrity sha512-uIAUQbzow2NxFsKmgOnogUA5A6oQ4ZCJoAet4hhe1RwUw54Tydn1tkpHKMZKbqloTMYAZ0CtCF3MoITAwMJWHw==
+  dependencies:
+    "@types/geojson" "*"
 
 "@types/mdast@^3.0.0":
   version "3.0.3"
@@ -7936,6 +7953,11 @@ last-call-webpack-plugin@^3.0.0:
     lodash "^4.17.5"
     webpack-sources "^1.1.0"
 
+leaflet@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.7.1.tgz#10d684916edfe1bf41d688a3b97127c0322a2a19"
+  integrity sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==
+
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -10324,6 +10346,13 @@ react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+"react-leaflet@>=3.1.0 <3.2.0 || ^3.2.1":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-leaflet/-/react-leaflet-3.1.0.tgz#42deb5e454518016eff8bc85511ae58812f910f5"
+  integrity sha512-kdZS8NYbYFPmkQr7zSDR2gkKGFeWvkxqoqcmZEckzHL4d5c85dJ2gbbqhaPDpmWWgaRw9O29uA/77qpKmK4mTQ==
+  dependencies:
+    "@react-leaflet/core" "^1.0.2"
 
 react-markdown@^6.0.2:
   version "6.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3469,6 +3469,11 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+build-url-ts@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/build-url-ts/-/build-url-ts-6.0.1.tgz#017c0397b044df5db92d587d8634c7464f3d9c32"
+  integrity sha512-hd7KdiTLQUI1JYOzC8uJQj98eUaDlpRxNQIF87+v+4WzEUa4eldVGok5OENSXGIDo138IrZIwci1XSbuusmsfQ==
+
 builtin-modules@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"


### PR DESCRIPTION
this wraps a bunch of preview-related changes:
 - new new lending page on /preview
 - all the previews are linked from there including:
     - two mfd plot styles
     - a basic leaflet map
     - a rupsetdiags report wrappin in ifram (via mui)
     - a views view that mashes up some of the above in a list of cards 
- closing #34 #19 & #20 

Note that there are no tests on these preview features! so they wreck our coverage stats :( 