### PR TITLE
Feature/37 diagnostics report

### DIFF
--- a/src/.env.development
+++ b/src/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_GRAPHQL_API='http://10.10.10.30:5000/graphql'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,6 @@ import MenuBar from './components/MenuBar';
 import Preview from './components/Preview';
 import PreviewMFD from './components/PreviewMFD';
 import PreviewLineMFD from './components/PreviewLineMFD';
-import RuptureSetDiags from './components/RuptureSetDiags';
 import RuptureSetViews from './components/RuptureSetViews';
 import HazardMap from './components/HazardMap';
 import Find from './components/Find';
@@ -146,7 +145,7 @@ function AppRoot(props: { environment?: Environment }): React.ReactElement {
               <Route path="/RuptureGenerationTask/:id">
                 <RuptureGenerationTask />
               </Route>
-              <Route path="/FileDetail/:id">
+              <Route path="/FileDetail/:id/:tab?">
                 <FileDetail />
               </Route>
               <Route path="/Search">
@@ -163,9 +162,6 @@ function AppRoot(props: { environment?: Environment }): React.ReactElement {
               </Route>
               <Route path="/Preview/lineMFD">
                 <PreviewLineMFD />
-              </Route>
-              <Route path="/Preview/diags">
-                <RuptureSetDiags />
               </Route>
               <Route path="/Preview/views">
                 <RuptureSetViews />

--- a/src/components/FileDetail.tsx
+++ b/src/components/FileDetail.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { useLazyLoadQuery, useQueryLoader } from 'react-relay';
 import { useHistory, useParams } from 'react-router-dom';
 import FileDetailTab, { fileDetailTabQuery } from './FileDetailTab';
-import KeyValueTable from './KeyValueTable';
+
 import RuptureSetDiags from './RuptureSetDiags';
 import { FileDetailQuery } from './__generated__/FileDetailQuery.graphql';
 import { FileDetailTabQuery } from './__generated__/FileDetailTabQuery.graphql';
@@ -85,11 +85,16 @@ const FileDetail: React.FC = () => {
   const hasRuptureSet = ['fault_model', 'max_jump_distance', 'scaling_relationship'].every((k) =>
     metaKeys?.includes(k),
   );
+  const metaAsString = data?.node?.meta?.map((kv) => ' ' + kv?.k + ': ' + kv?.v).toString() ?? '';
 
   const renderTab = () => {
     switch (tab) {
       case 'RuptureSetDiagnostics':
-        return <Box className={classes.tabPanel}>{hasRuptureSet && <RuptureSetDiags fileId={id} />}</Box>;
+        return (
+          <Box className={classes.tabPanel}>
+            {hasRuptureSet && <RuptureSetDiags fileId={id} metaAsString={metaAsString} />}
+          </Box>
+        );
       default:
         return (
           <Box className={classes.tabPanel}>
@@ -108,15 +113,14 @@ const FileDetail: React.FC = () => {
           orientation="vertical"
           value={tab ?? 'FileDetail'}
           onChange={(e, val) => history.push(`/FileDetail/${id}/${val}`)}
-          className={classes.tab}
         >
-          <Tab label="File Detail" id="fileDetailTab" value="FileDetail" />
-          {hasRuptureSet && <Tab label="Rupture Set Diagnostics" id="ruptureSetTab" value="RuptureSetDiagnostics" />}
+          <Tab label="File Detail" id="fileDetailTab" value="FileDetail" className={classes.tab} />
+          {hasRuptureSet && (
+            <Tab label="Diagnostics" id="ruptureSetTab" value="RuptureSetDiagnostics" className={classes.tab} />
+          )}
         </Tabs>
         {renderTab()}
       </Box>
-
-      {data?.node?.meta && <KeyValueTable header="Meta" data={data?.node?.meta} />}
     </>
   );
 };

--- a/src/components/FileDetailTab.tsx
+++ b/src/components/FileDetailTab.tsx
@@ -2,9 +2,9 @@ import { Typography } from '@material-ui/core';
 import { graphql } from 'babel-plugin-relay/macro';
 import React from 'react';
 import { PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import { Link } from 'react-router-dom';
 import { formatBytes } from './FileDetail';
 import { FileDetailTabQuery } from './__generated__/FileDetailTabQuery.graphql';
+import KeyValueTable from './KeyValueTable';
 
 export const fileDetailTabQuery = graphql`
   query FileDetailTabQuery($id: ID!) {
@@ -15,17 +15,9 @@ export const fileDetailTabQuery = graphql`
         file_size
         file_url
         md5_digest
-        relations {
-          edges {
-            node {
-              role
-              thing {
-                ... on Node {
-                  id
-                }
-              }
-            }
-          }
+        meta {
+          k
+          v
         }
       }
     }
@@ -54,23 +46,9 @@ const FileDetailTab: React.FC<FileDetailTabProps> = ({ queryRef }: FileDetailTab
         <strong>MD5 digest:</strong> {data?.node?.md5_digest}
       </Typography>
       <Typography>
-        <strong>Written by: </strong>
-        {data?.node?.relations?.edges
-          ?.filter((e) => e?.node?.role === 'WRITE')
-          ?.map((e, i, { length }) => {
-            return (
-              <React.Fragment key={e?.node?.thing?.id}>
-                <Link to={`/RuptureGenerationTask/${e?.node?.thing?.id}`}>
-                  {Buffer.from(e?.node?.thing?.id ?? '', 'base64').toString()}
-                </Link>
-                {i + 1 !== length && <span>, </span>}
-              </React.Fragment>
-            );
-          })}
-      </Typography>
-      <Typography>
         <a href={data?.node?.file_url ?? ''}>Download</a>
       </Typography>
+      {data?.node?.meta && <KeyValueTable header="Meta" data={data?.node?.meta} />}
     </>
   );
 };

--- a/src/components/FileDetailTab.tsx
+++ b/src/components/FileDetailTab.tsx
@@ -1,0 +1,78 @@
+import { Typography } from '@material-ui/core';
+import { graphql } from 'babel-plugin-relay/macro';
+import React from 'react';
+import { PreloadedQuery, usePreloadedQuery } from 'react-relay';
+import { Link } from 'react-router-dom';
+import { formatBytes } from './FileDetail';
+import { FileDetailTabQuery } from './__generated__/FileDetailTabQuery.graphql';
+
+export const fileDetailTabQuery = graphql`
+  query FileDetailTabQuery($id: ID!) {
+    node(id: $id) {
+      ... on File {
+        id
+        file_name
+        file_size
+        file_url
+        md5_digest
+        relations {
+          edges {
+            node {
+              role
+              thing {
+                ... on Node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface FileDetailTabProps {
+  queryRef: PreloadedQuery<FileDetailTabQuery, Record<string, unknown>>;
+}
+
+const FileDetailTab: React.FC<FileDetailTabProps> = ({ queryRef }: FileDetailTabProps) => {
+  const data = usePreloadedQuery<FileDetailTabQuery>(fileDetailTabQuery, queryRef);
+
+  return (
+    <>
+      <Typography variant="h5" gutterBottom>
+        File Detail (id: {data?.node?.id})
+      </Typography>
+      <Typography>
+        <strong>File name:</strong> {data?.node?.file_name}
+      </Typography>
+      <Typography>
+        <strong>File size:</strong> {formatBytes(data?.node?.file_size ?? 0)}
+      </Typography>
+      <Typography>
+        <strong>MD5 digest:</strong> {data?.node?.md5_digest}
+      </Typography>
+      <Typography>
+        <strong>Written by: </strong>
+        {data?.node?.relations?.edges
+          ?.filter((e) => e?.node?.role === 'WRITE')
+          ?.map((e, i, { length }) => {
+            return (
+              <React.Fragment key={e?.node?.thing?.id}>
+                <Link to={`/RuptureGenerationTask/${e?.node?.thing?.id}`}>
+                  {Buffer.from(e?.node?.thing?.id ?? '', 'base64').toString()}
+                </Link>
+                {i + 1 !== length && <span>, </span>}
+              </React.Fragment>
+            );
+          })}
+      </Typography>
+      <Typography>
+        <a href={data?.node?.file_url ?? ''}>Download</a>
+      </Typography>
+    </>
+  );
+};
+
+export default FileDetailTab;

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -77,20 +77,6 @@ function Preview(): React.ReactElement {
       <Card className={classes.root}>
         <CardContent>
           <Typography color="textPrimary" variant="h5" gutterBottom>
-            Inline report Rupture Set Diagnostics
-          </Typography>
-          <Typography className={classes.pos} component="p">
-            Take a static HTML open report and wrap it to make if more usable.
-            <Button size="small" href="/preview/diags">
-              go
-            </Button>
-          </Typography>
-        </CardContent>
-      </Card>
-
-      <Card className={classes.root}>
-        <CardContent>
-          <Typography color="textPrimary" variant="h5" gutterBottom>
             Mixed static and dynamic content
           </Typography>
           <Typography className={classes.pos} component="p">

--- a/src/components/RuptureSetDiags.tsx
+++ b/src/components/RuptureSetDiags.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
-import CardActionArea from '@material-ui/core/CardActionArea';
-import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import CardMedia from '@material-ui/core/CardMedia';
-import Button from '@material-ui/core/Button';
 import { Typography } from '@material-ui/core';
 
 import buildUrl from 'build-url-ts';
@@ -22,45 +19,36 @@ const useStyles = makeStyles({
   },
 });
 
-// const indexMap: Record<string, string> = {
-//   RmlsZTo3ODYuMGRiR1hT: 'DATA6/RmlsZTo3ODYuMGRiR1hT/',
-//   RmlsZTo3NzEuMGRlR2pw: 'DATA6/RmlsZTo3NzEuMGRlR2pw/',
-// };
+interface RuptureSetDiagsProps {
+  fileId: string;
+}
 
-const hash = 'subsection-count';
-
-const reportUrl = buildUrl(reportBaseUrl, {
-  path: '/RmlsZTo3ODYuMGRiR1hT' + '/DiagnosticsReport/index.html',
-  hash: hash,
-});
-
-const RuptureSetDiags: React.FC = () => {
+const RuptureSetDiags: React.FC<RuptureSetDiagsProps> = ({ fileId }: RuptureSetDiagsProps) => {
   const classes = useStyles();
 
-  // return <iframe src={reportUrl} width="1000" height="600" />;
+  const hash = 'subsection-count';
+
+  const reportUrl = buildUrl(reportBaseUrl, {
+    path: `/${fileId}/DiagnosticsReport/index.html`,
+    hash: hash,
+  });
 
   return (
     <Card className={classes.root}>
-      <CardActionArea>
-        <CardContent>
-          <Typography gutterBottom variant="h5" component="h2">
-            Rupture Set Diagnostics Report {'RmlsZTo3ODYuMGRiR1hT'}
-          </Typography>
-          <Typography variant="body2" color="textSecondary" component="p">
-            fault_model: CFM_0_9_SANSTVZ_D90; min_sub_sects_per_parent: 2; min_sub_sections: 3; max_jump_distance: 15
-            adaptive_min_distance: 6; thinning_factor: 0.0; scaling_relationship: TMG_CRU_2017
-          </Typography>
-        </CardContent>
-        <CardMedia className={classes.media} src={reportUrl} title="DiagnosticsReport" component="iframe" />
-      </CardActionArea>
-      <CardActions>
+      <CardContent>
+        <Typography gutterBottom variant="h5" component="h2">
+          Rupture Set Diagnostics Report {`${fileId}`}
+        </Typography>
+      </CardContent>
+      <CardMedia className={classes.media} src={reportUrl} title="DiagnosticsReport" component="iframe" />
+      {/* <CardActions>
         <Button size="small" color="primary">
           Share
         </Button>
         <Button size="small" color="primary">
           Learn More
         </Button>
-      </CardActions>
+      </CardActions> */}
     </Card>
   );
 };

--- a/src/components/RuptureSetDiags.tsx
+++ b/src/components/RuptureSetDiags.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import CardMedia from '@material-ui/core/CardMedia';
@@ -8,22 +8,26 @@ import { Typography } from '@material-ui/core';
 import buildUrl from 'build-url-ts';
 
 const reportBaseUrl = 'http://nzshm22-static-reports.s3-website-ap-southeast-2.amazonaws.com/opensha/DATA';
-//http://nzshm22-rupset-diags-poc.s3-website-ap-southeast-2.amazonaws.com';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    maxWidth: 1000,
+    padding: theme.spacing(0),
+  },
+  cardContent: {
+    paddingTop: 0,
   },
   media: {
     height: 600,
+    padding: theme.spacing(0),
   },
-});
+}));
 
 interface RuptureSetDiagsProps {
   fileId: string;
+  metaAsString: string;
 }
 
-const RuptureSetDiags: React.FC<RuptureSetDiagsProps> = ({ fileId }: RuptureSetDiagsProps) => {
+const RuptureSetDiags: React.FC<RuptureSetDiagsProps> = ({ fileId, metaAsString }: RuptureSetDiagsProps) => {
   const classes = useStyles();
 
   const hash = 'subsection-count';
@@ -35,20 +39,15 @@ const RuptureSetDiags: React.FC<RuptureSetDiagsProps> = ({ fileId }: RuptureSetD
 
   return (
     <Card className={classes.root}>
-      <CardContent>
+      <CardContent className={classes.cardContent}>
         <Typography gutterBottom variant="h5" component="h2">
           Rupture Set Diagnostics Report {`${fileId}`}
         </Typography>
+        <Typography variant="body2" color="textSecondary" component="p">
+          {metaAsString}
+        </Typography>
       </CardContent>
       <CardMedia className={classes.media} src={reportUrl} title="DiagnosticsReport" component="iframe" />
-      {/* <CardActions>
-        <Button size="small" color="primary">
-          Share
-        </Button>
-        <Button size="small" color="primary">
-          Learn More
-        </Button>
-      </CardActions> */}
     </Card>
   );
 };

--- a/src/components/__generated__/FileDetailQuery.graphql.ts
+++ b/src/components/__generated__/FileDetailQuery.graphql.ts
@@ -3,31 +3,16 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from "relay-runtime";
-export type FileRole = "READ" | "READ_WRITE" | "UNDEFINED" | "WRITE" | "%future added value";
 export type FileDetailQueryVariables = {
     id: string;
 };
 export type FileDetailQueryResponse = {
     readonly node: {
         readonly id?: string;
-        readonly file_name?: string | null;
-        readonly file_size?: number | null;
-        readonly file_url?: string | null;
-        readonly md5_digest?: string | null;
         readonly meta?: ReadonlyArray<{
             readonly k: string | null;
             readonly v: string | null;
         } | null> | null;
-        readonly relations?: {
-            readonly edges: ReadonlyArray<{
-                readonly node: {
-                    readonly role: FileRole;
-                    readonly thing: {
-                        readonly id?: string;
-                    };
-                } | null;
-            } | null>;
-        } | null;
     } | null;
 };
 export type FileDetailQuery = {
@@ -45,28 +30,9 @@ query FileDetailQuery(
     __typename
     ... on File {
       id
-      file_name
-      file_size
-      file_url
-      md5_digest
       meta {
         k
         v
-      }
-      relations {
-        edges {
-          node {
-            role
-            thing {
-              __typename
-              ... on Node {
-                __isNode: __typename
-                id
-              }
-            }
-            id
-          }
-        }
       }
     }
     id
@@ -99,34 +65,6 @@ v2 = {
 v3 = {
   "alias": null,
   "args": null,
-  "kind": "ScalarField",
-  "name": "file_name",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "file_size",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "file_url",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "md5_digest",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
   "concreteType": "KeyValuePair",
   "kind": "LinkedField",
   "name": "meta",
@@ -148,28 +86,6 @@ v7 = {
     }
   ],
   "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "role",
-  "storageKey": null
-},
-v9 = {
-  "kind": "InlineFragment",
-  "selections": [
-    (v2/*: any*/)
-  ],
-  "type": "Node",
-  "abstractKey": "__isNode"
-},
-v10 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "__typename",
-  "storageKey": null
 };
 return {
   "fragment": {
@@ -190,57 +106,7 @@ return {
             "kind": "InlineFragment",
             "selections": [
               (v2/*: any*/),
-              (v3/*: any*/),
-              (v4/*: any*/),
-              (v5/*: any*/),
-              (v6/*: any*/),
-              (v7/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "FileRelationConnection",
-                "kind": "LinkedField",
-                "name": "relations",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "FileRelationEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "FileRelation",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": [
-                          (v8/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": null,
-                            "kind": "LinkedField",
-                            "name": "thing",
-                            "plural": false,
-                            "selections": [
-                              (v9/*: any*/)
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              }
+              (v3/*: any*/)
             ],
             "type": "File",
             "abstractKey": null
@@ -266,64 +132,18 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v10/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
           (v2/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
-              (v3/*: any*/),
-              (v4/*: any*/),
-              (v5/*: any*/),
-              (v6/*: any*/),
-              (v7/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "FileRelationConnection",
-                "kind": "LinkedField",
-                "name": "relations",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "FileRelationEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "FileRelation",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": [
-                          (v8/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": null,
-                            "kind": "LinkedField",
-                            "name": "thing",
-                            "plural": false,
-                            "selections": [
-                              (v10/*: any*/),
-                              (v9/*: any*/)
-                            ],
-                            "storageKey": null
-                          },
-                          (v2/*: any*/)
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              }
+              (v3/*: any*/)
             ],
             "type": "File",
             "abstractKey": null
@@ -334,14 +154,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f1df92f719ea5acef1b46e1e8557f115",
+    "cacheID": "87d1c121fba7e0a45a0707cb303442b3",
     "id": null,
     "metadata": {},
     "name": "FileDetailQuery",
     "operationKind": "query",
-    "text": "query FileDetailQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ... on File {\n      id\n      file_name\n      file_size\n      file_url\n      md5_digest\n      meta {\n        k\n        v\n      }\n      relations {\n        edges {\n          node {\n            role\n            thing {\n              __typename\n              ... on Node {\n                __isNode: __typename\n                id\n              }\n            }\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query FileDetailQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ... on File {\n      id\n      meta {\n        k\n        v\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '75e7482d8e1779b143d9c1a0d53c2000';
+(node as any).hash = '52942424f61d7e0e8c9f88c282d95ab2';
 export default node;

--- a/src/components/__generated__/FileDetailTabQuery.graphql.ts
+++ b/src/components/__generated__/FileDetailTabQuery.graphql.ts
@@ -3,7 +3,6 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from "relay-runtime";
-export type FileRole = "READ" | "READ_WRITE" | "UNDEFINED" | "WRITE" | "%future added value";
 export type FileDetailTabQueryVariables = {
     id: string;
 };
@@ -14,16 +13,10 @@ export type FileDetailTabQueryResponse = {
         readonly file_size?: number | null;
         readonly file_url?: string | null;
         readonly md5_digest?: string | null;
-        readonly relations?: {
-            readonly edges: ReadonlyArray<{
-                readonly node: {
-                    readonly role: FileRole;
-                    readonly thing: {
-                        readonly id?: string;
-                    };
-                } | null;
-            } | null>;
-        } | null;
+        readonly meta?: ReadonlyArray<{
+            readonly k: string | null;
+            readonly v: string | null;
+        } | null> | null;
     } | null;
 };
 export type FileDetailTabQuery = {
@@ -45,20 +38,9 @@ query FileDetailTabQuery(
       file_size
       file_url
       md5_digest
-      relations {
-        edges {
-          node {
-            role
-            thing {
-              __typename
-              ... on Node {
-                __isNode: __typename
-                id
-              }
-            }
-            id
-          }
-        }
+      meta {
+        k
+        v
       }
     }
     id
@@ -119,23 +101,26 @@ v6 = {
 v7 = {
   "alias": null,
   "args": null,
-  "kind": "ScalarField",
-  "name": "role",
-  "storageKey": null
-},
-v8 = {
-  "kind": "InlineFragment",
+  "concreteType": "KeyValuePair",
+  "kind": "LinkedField",
+  "name": "meta",
+  "plural": true,
   "selections": [
-    (v2/*: any*/)
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "k",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "v",
+      "storageKey": null
+    }
   ],
-  "type": "Node",
-  "abstractKey": "__isNode"
-},
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "__typename",
   "storageKey": null
 };
 return {
@@ -161,52 +146,7 @@ return {
               (v4/*: any*/),
               (v5/*: any*/),
               (v6/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "FileRelationConnection",
-                "kind": "LinkedField",
-                "name": "relations",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "FileRelationEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "FileRelation",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": [
-                          (v7/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": null,
-                            "kind": "LinkedField",
-                            "name": "thing",
-                            "plural": false,
-                            "selections": [
-                              (v8/*: any*/)
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              }
+              (v7/*: any*/)
             ],
             "type": "File",
             "abstractKey": null
@@ -232,7 +172,13 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v9/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
           (v2/*: any*/),
           {
             "kind": "InlineFragment",
@@ -241,54 +187,7 @@ return {
               (v4/*: any*/),
               (v5/*: any*/),
               (v6/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "FileRelationConnection",
-                "kind": "LinkedField",
-                "name": "relations",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "FileRelationEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "FileRelation",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": [
-                          (v7/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": null,
-                            "kind": "LinkedField",
-                            "name": "thing",
-                            "plural": false,
-                            "selections": [
-                              (v9/*: any*/),
-                              (v8/*: any*/)
-                            ],
-                            "storageKey": null
-                          },
-                          (v2/*: any*/)
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              }
+              (v7/*: any*/)
             ],
             "type": "File",
             "abstractKey": null
@@ -299,14 +198,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "61adb6db64adb9505fba7e5ed70185cf",
+    "cacheID": "5a4c6613acd285af430a2cc84869c59b",
     "id": null,
     "metadata": {},
     "name": "FileDetailTabQuery",
     "operationKind": "query",
-    "text": "query FileDetailTabQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ... on File {\n      id\n      file_name\n      file_size\n      file_url\n      md5_digest\n      relations {\n        edges {\n          node {\n            role\n            thing {\n              __typename\n              ... on Node {\n                __isNode: __typename\n                id\n              }\n            }\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query FileDetailTabQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ... on File {\n      id\n      file_name\n      file_size\n      file_url\n      md5_digest\n      meta {\n        k\n        v\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '44135d54585be7df18052088cc05c7e5';
+(node as any).hash = '9ce4bec27ce248e27419531f67bedcf6';
 export default node;

--- a/src/components/__generated__/FileDetailTabQuery.graphql.ts
+++ b/src/components/__generated__/FileDetailTabQuery.graphql.ts
@@ -1,0 +1,312 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+export type FileRole = "READ" | "READ_WRITE" | "UNDEFINED" | "WRITE" | "%future added value";
+export type FileDetailTabQueryVariables = {
+    id: string;
+};
+export type FileDetailTabQueryResponse = {
+    readonly node: {
+        readonly id?: string;
+        readonly file_name?: string | null;
+        readonly file_size?: number | null;
+        readonly file_url?: string | null;
+        readonly md5_digest?: string | null;
+        readonly relations?: {
+            readonly edges: ReadonlyArray<{
+                readonly node: {
+                    readonly role: FileRole;
+                    readonly thing: {
+                        readonly id?: string;
+                    };
+                } | null;
+            } | null>;
+        } | null;
+    } | null;
+};
+export type FileDetailTabQuery = {
+    readonly response: FileDetailTabQueryResponse;
+    readonly variables: FileDetailTabQueryVariables;
+};
+
+
+
+/*
+query FileDetailTabQuery(
+  $id: ID!
+) {
+  node(id: $id) {
+    __typename
+    ... on File {
+      id
+      file_name
+      file_size
+      file_url
+      md5_digest
+      relations {
+        edges {
+          node {
+            role
+            thing {
+              __typename
+              ... on Node {
+                __isNode: __typename
+                id
+              }
+            }
+            id
+          }
+        }
+      }
+    }
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "file_name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "file_size",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "file_url",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "md5_digest",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "role",
+  "storageKey": null
+},
+v8 = {
+  "kind": "InlineFragment",
+  "selections": [
+    (v2/*: any*/)
+  ],
+  "type": "Node",
+  "abstractKey": "__isNode"
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "FileDetailTabQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FileRelationConnection",
+                "kind": "LinkedField",
+                "name": "relations",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FileRelationEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "FileRelation",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v7/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": null,
+                            "kind": "LinkedField",
+                            "name": "thing",
+                            "plural": false,
+                            "selections": [
+                              (v8/*: any*/)
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "File",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "QueryRoot",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "FileDetailTabQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v9/*: any*/),
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FileRelationConnection",
+                "kind": "LinkedField",
+                "name": "relations",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FileRelationEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "FileRelation",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v7/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": null,
+                            "kind": "LinkedField",
+                            "name": "thing",
+                            "plural": false,
+                            "selections": [
+                              (v9/*: any*/),
+                              (v8/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "File",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "61adb6db64adb9505fba7e5ed70185cf",
+    "id": null,
+    "metadata": {},
+    "name": "FileDetailTabQuery",
+    "operationKind": "query",
+    "text": "query FileDetailTabQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ... on File {\n      id\n      file_name\n      file_size\n      file_url\n      md5_digest\n      relations {\n        edges {\n          node {\n            role\n            thing {\n              __typename\n              ... on Node {\n                __isNode: __typename\n                id\n              }\n            }\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '44135d54585be7df18052088cc05c7e5';
+export default node;

--- a/src/tests/FileDetail.test.tsx
+++ b/src/tests/FileDetail.test.tsx
@@ -5,6 +5,7 @@ import ReactRouter from 'react-router';
 import { RelayEnvironmentProvider } from 'react-relay/hooks';
 import { cleanup, render } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
+import { fileDetailTabQuery } from '../components/FileDetailTab';
 
 const mockResolver = {
   File: () => ({
@@ -49,8 +50,10 @@ describe('FileDetail component', () => {
     jest.spyOn(ReactRouter, 'useParams').mockReturnValue({ id: '1234' });
     const environment = createMockEnvironment();
     environment.mock.queueOperationResolver((operation) => MockPayloadGenerator.generate(operation, mockResolver));
+    environment.mock.queueOperationResolver((operation) => MockPayloadGenerator.generate(operation, mockResolver));
+    environment.mock.queuePendingOperation(fileDetailTabQuery, { id: '1234' });
 
-    const { findByText } = setup(environment);
+    const { findByText, queryByText } = setup(environment);
     expect(await findByText('Download')).toHaveAttribute('href', 'test_url');
     expect(await findByText('RuptureGenerationTask:4')).toHaveAttribute(
       'href',
@@ -59,6 +62,30 @@ describe('FileDetail component', () => {
     expect(await findByText('testFile.zip')).toBeVisible();
     expect(await findByText('1000 Bytes')).toBeVisible();
     expect(await findByText('test_md5')).toBeVisible();
+    expect(queryByText('Rupture Set Diagnostics')).not.toBeInTheDocument();
+  });
+
+  it('shows Rupture Set Diagnostics tab', async () => {
+    jest.spyOn(ReactRouter, 'useParams').mockReturnValue({ id: '1234', tab: 'RuptureSetDiagnostics' });
+
+    const mockRuptureResolver = {
+      File: () => ({
+        meta: [
+          { k: 'fault_model', v: '' },
+          { k: 'max_jump_distance', v: '' },
+          { k: 'scaling_relationship', v: '' },
+        ],
+      }),
+    };
+
+    const environment = createMockEnvironment();
+    environment.mock.queueOperationResolver((operation) =>
+      MockPayloadGenerator.generate(operation, mockRuptureResolver),
+    );
+    environment.mock.queuePendingOperation(fileDetailTabQuery, { id: '1234' });
+
+    const { findByText } = setup(environment);
+    expect(await findByText('Rupture Set Diagnostics')).toBeVisible();
   });
 
   it('displays not found when no matching id', async () => {

--- a/src/tests/FileDetail.test.tsx
+++ b/src/tests/FileDetail.test.tsx
@@ -55,14 +55,10 @@ describe('FileDetail component', () => {
 
     const { findByText, queryByText } = setup(environment);
     expect(await findByText('Download')).toHaveAttribute('href', 'test_url');
-    expect(await findByText('RuptureGenerationTask:4')).toHaveAttribute(
-      'href',
-      '/RuptureGenerationTask/UnVwdHVyZUdlbmVyYXRpb25UYXNrOjQ=',
-    );
     expect(await findByText('testFile.zip')).toBeVisible();
     expect(await findByText('1000 Bytes')).toBeVisible();
     expect(await findByText('test_md5')).toBeVisible();
-    expect(queryByText('Rupture Set Diagnostics')).not.toBeInTheDocument();
+    expect(queryByText('Diagnostics')).not.toBeInTheDocument();
   });
 
   it('shows Rupture Set Diagnostics tab', async () => {
@@ -85,7 +81,7 @@ describe('FileDetail component', () => {
     environment.mock.queuePendingOperation(fileDetailTabQuery, { id: '1234' });
 
     const { findByText } = setup(environment);
-    expect(await findByText('Rupture Set Diagnostics')).toBeVisible();
+    expect(await findByText('Diagnostics')).toBeVisible();
   });
 
   it('displays not found when no matching id', async () => {


### PR DESCRIPTION
Added new route to view diagnostics report for RuptureSet file:

![image](https://user-images.githubusercontent.com/21334474/126056170-8bc47fa3-b416-4483-b157-d04b2bff6d86.png)

Direct link to route: /FileDetail/RmlsZTo4NTkuMDM2Z2Rw/RuptureSetDiagnostics

Closes #37 